### PR TITLE
add testnet3 support and pass policy

### DIFF
--- a/backend_bci.js
+++ b/backend_bci.js
@@ -4,7 +4,17 @@
 
 // Back-end for blockchain.info API
 
-var backend = { link: '<a href="https://blockchain.info/" target=_blank rel="noopener noreferrer">blockchain.info</a>', adr_page: 'https://blockchain.info/address/' };
+var backend = { api: 'https://blockchain.info', link: '<a href="https://blockchain.info/" target=_blank rel="noopener noreferrer">blockchain.info</a>', adr_page: 'https://blockchain.info/address/' };
+
+backend.test_set = function(test)
+{
+	if (test) {
+		backend.api = 'https://testnet.blockchain.info';
+		backend.adr_page = 'https://testnet.blockchain.info/address/';
+		return true;
+	}
+	return false;
+};
 
 function backend_balance_cb(res)
 {
@@ -41,19 +51,19 @@ backend.get_balance = function(adr, cb)
 {
 	this.balance_cb = cb;
 	
-	js.ajax('GET', 'https://blockchain.info/q/addressbalance/' + adr, 'cors=true', backend_balance_cb);
+	js.ajax('GET', backend.api + '/q/addressbalance/' + adr, 'cors=true', backend_balance_cb);
 };//___________________________________________________________________________
 
 backend.get_utxo = function(adr, cb)
 {
 	this.unspent_cb = cb;
 	
-	js.ajax('GET', 'https://blockchain.info/unspent?active=' + adr, 'cors=true', backend_unspent_cb);
+	js.ajax('GET', backend.api + '/unspent?active=' + adr, 'cors=true', backend_unspent_cb);
 };//___________________________________________________________________________
 
 backend.send = function(tx, cb)
 {
 	this.send_cb = cb;
 
-	js.ajax('POST', 'https://blockchain.info/pushtx', 'tx=' + tx, backend_send_cb);
+	js.ajax('POST', backend.api + '/pushtx', 'tx=' + tx, backend_send_cb);
 };//___________________________________________________________________________

--- a/backend_exp.js
+++ b/backend_exp.js
@@ -4,7 +4,12 @@
 
 // Back-end for blockexplorer.com API
 
-var backend = { link: '<a href="https://blockexplorer.com/" target=_blank rel="noopener noreferrer">blockexplorer.com</a>', adr_page: 'https://blockexplorer.com/address/' };
+var backend = { api: 'https://blockexplorer.com', link: '<a href="https://blockexplorer.com/" target=_blank rel="noopener noreferrer">blockexplorer.com</a>', adr_page: 'https://blockexplorer.com/address/' };
+
+backend.test_set = function(test)
+{
+	return false;
+};
 
 function backend_balance_cb(res)
 {
@@ -45,19 +50,19 @@ backend.get_balance = function(adr, cb)
 {
 	this.balance_cb = cb;
 	
-	js.ajax('GET', 'https://blockexplorer.com/api/addr/' + adr + '/balance', '', backend_balance_cb);
+	js.ajax('GET', backend.api + '/api/addr/' + adr + '/balance', '', backend_balance_cb);
 };//___________________________________________________________________________
 
 backend.get_utxo = function(adr, cb)
 {
 	this.unspent_cb = cb;
 	
-	js.ajax('GET', 'https://blockexplorer.com/api/addr/' + adr + '/utxo', '', backend_unspent_cb);
+	js.ajax('GET', backend.api + '/api/addr/' + adr + '/utxo', '', backend_unspent_cb);
 };//___________________________________________________________________________
 
 backend.send = function(tx, cb)
 {
 	this.send_cb = cb;
 
-	js.ajax('POST', 'https://blockexplorer.com/api/tx/send', 'rawtx=' + tx, backend_send_cb);
+	js.ajax('POST', backend.api + '/api/tx/send', 'rawtx=' + tx, backend_send_cb);
 };//___________________________________________________________________________

--- a/btc.js
+++ b/btc.js
@@ -107,13 +107,14 @@ btc.new_pk = function(sk, uncompressed) // Generate a public key from a private 
 	return btc.bin2hex(encoded);
 };//___________________________________________________________________________
 
-btc.pk2adr = function(pk, is_script_hash)
+btc.pk2adr = function(pk, test, is_script_hash)
 {
 	var r = btc.hex2bin(pk);
 	
 	if(!is_script_hash) r = RIPEMD160(SHA256(r));
 
-	r.unshift(0x00);
+	if (test) r.unshift(0x6F);
+	else r.unshift(0x00);
 
 	var checksum = SHA256(SHA256(r)).slice(0, 4);
 
@@ -123,6 +124,7 @@ btc.pk2adr = function(pk, is_script_hash)
 btc.sk2wif = function(sk, uncompressed)
 {
 	var r = [0x80].concat(sk);
+	if (test) r = [0xef].concat(sk);
 	
 	if(!uncompressed) r = r.concat([0x01]);
 
@@ -152,6 +154,9 @@ btc.decode_adr = function(adr)
 		if(ver == 0x00 && len == 25){ a.type = 'standard'; return a; }
 		if(ver == 0x05 && len == 25){ a.type = 'multisig'; return a; }
 
+		if(ver == 0x6F && len == 25){ a.type = 'standard'; return a; }
+		if(ver == 0xC4 && len == 25){ a.type = 'multisig'; return a; }
+
 		if(ver == 0x80 && len == 37                        ){ a.type = 'wifkey'; a.uncompressed =  true; return a; }
 		if(ver == 0x80 && len == 38 && bytes[len-5] == 0x01){ a.type = 'wifkey'; a.uncompressed = false; return a; }
 	}
@@ -169,10 +174,28 @@ btc.extend = function(pass)
 	return SHA256(pass);
 };//___________________________________________________________________________
 
+btc.entropy = function(pass)
+{
+	var phrase = pass.split("");
+	var probs = phrase.reduce((prev, curr) => (prev[curr] = ++prev[curr] || 1, prev), {})
+	var ent = 0;
+	console.log(probs)
+	for (var k in probs) {
+		//var value = dict[key];
+		var p = probs[k] / phrase.length;
+		ent += (p*Math.log2(p))
+	}
+	ent *= -1;
+	if (ent>3) return true;
+	else return false;
+};//___________________________________________________________________________
+
 // Generate a private and public keypair, with address and WIF address.
 
-btc.get_keys = function(pass)
+btc.get_keys = function(pass, test)
 {
+	if (!this.entropy(pass)) return false;
+
 	var sk = this.extend(pass), uncompressed = false; // first, assume regular password
 
 	var adr = this.decode_adr(pass);
@@ -189,7 +212,7 @@ btc.get_keys = function(pass)
 
 	var pk = this.new_pk(sk, uncompressed);
 
-	return { 'sk': sk, 'pk': pk, 'adr': this.pk2adr(pk), 'wif': this.sk2wif(sk, uncompressed) };
+	return { 'sk': sk, 'pk': pk, 'adr': this.pk2adr(pk, test), 'wif': this.sk2wif(sk, uncompressed, test) };
 };//___________________________________________________________________________
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 	input { height:18px; padding:3px 4px; font-size:14px; margin:2px 0; }
 	button{ padding:4px 12px; font-size:14px; }
 	
-	#page{ width:496px; height:244px; position:absolute; top:0; right:0; left:0; bottom:0; margin:auto;  background:#F5F5F5; text-align:center; font-family:arial; font-size:14px; overflow:hidden; }
+	#page{ width:496px; height:255px; position:absolute; top:0; right:0; left:0; bottom:0; margin:auto;  background:#F5F5F5; text-align:center; font-family:arial; font-size:14px; overflow:hidden; }
 	#pass_form, #send_form{ padding:30px; color:#888; text-align:left; display:none; }
 	#pass_form{ text-align:center; display:none; }
 	#passphrase{ width:310px; }
@@ -45,7 +45,7 @@
 	<br><input id=passphrase type=password placeholder="Passphrase or private key" title="Can also use compressed WIF key.">&nbsp;<button type=submit>Open</button><br>
 	<br><br>Nothing is sent to our server, everything is done in the browser.<br>It gets utxo and sends signed txs via <span id=backend></span> API.
 	<br><br>You can download it from <a href='https://github.com/NxtChg/tsbw' target=_blank>github</a> and use it locally.
-	<div style="position:absolute; right:12px; bottom:8px;"><a href="bcc/">Bitcoin Cash version</a></div>
+	<div style="position:absolute; right:12px; bottom:8px;"><a id="testswitch" href="?test">Testnet</a> / <a href="bcc/">Bitcoin Cash Version</a></div>
 </form>
 
 <form id=send_form action="javascript:send_tx();">
@@ -62,13 +62,23 @@
 
 <script>
 
-var tx, keys, fee = 0.00002;
+var tx, keys, fee = 0.0009;
+
+var test = 0;
+var param = window.location.search.substring(1);
+if (param == "test") test = 1;
+if (backend.test_set(test)) {
+	console.log("Running on testnet.");
+	document.getElementById("testswitch").innerHTML = "Live";
+	var getUrl = window.location;
+	document.getElementById("testswitch").href = getUrl.pathname.split('?')[0];
+}
 
 function balance_cb(amount)
 {
 	if(isNaN(amount)) amount = '?'; else amount = js.format_money(amount, 8);
 
-	$('balance').innerHTML = "<span title='click to refresh' onclick='refresh(true);' style='cursor:pointer'>Balance: <b id=amt>" + amount + "</b> BTC</span> (<a href='" + backend.adr_page + keys.adr + "' target=_blank rel=\"noopener noreferrer\">transactions</a>)";
+	$('balance').innerHTML = "<span title='click to refresh' onclick='refresh(true);' style='cursor:pointer'>Balance: <b id=amt>" + amount + "</b> BTC</span> (<a href='" + backend.adr_page + keys.adr + "' target=_blank rel=\"noopener noreferrer\">Transactions</a>)";
 }//____________________________________________________________________________
 
 function refresh(set_amount)
@@ -82,7 +92,7 @@ function open_wallet()
 {
 	var pass = js.trim($('passphrase').value); if(pass.length < 1) return;
 
-	keys = btc.get_keys(pass); if(keys === false){ alert('Bad private key!'); return; }
+	keys = btc.get_keys(pass, test); if(keys === false){ alert('Bad private key or weak password, please try again.'); return; }
 
 	$('pass_form').hide();
 	$('send_form').show();
@@ -104,7 +114,7 @@ function broadcast_cb(res)
 	{
 		$('to'    ).value = '';
 		$('amount').value = '';
-		$('status').innerHTML = '<a href="https://blockchain.info/tx/' + tx.txid() + '" target=_blank rel="noopener noreferrer">Transaction</a> sent.';
+		$('status').innerHTML = '<a href="' + backend.api + '/tx/' + tx.txid() + '" target=_blank rel="noopener noreferrer">Transaction</a> sent.';
 	}
 	else $('status').innerHTML = 'Error: ' + res;
 
@@ -151,6 +161,7 @@ function send_tx()
 {
     var dst = js.trim($('to').value), amount = parseFloat(js.trim($('amount').value));
 
+	console.log(btc.decode_adr(dst));
     if(dst == '' || btc.decode_adr(dst) === false || isNaN(amount) || amount < 0.0001) return;
 
     if(confirm('Send ' + amount + ' BTC to ' + dst + '?'))


### PR DESCRIPTION
Testnet Compatibility & Better Password Enforcement

The API wrappers have been updated to support URI changes, primarily for switching the mode. Due to issues with weak passwords in [brain wallets](https://fc16.ifca.ai/preproceedings/36_Vasek.pdf) it is better to enforce stronger tokens. This is implemented by way of Shannon's Entropy to score the probability distribution of chars and threshold at a reasonable level.

 